### PR TITLE
fix: move index fetch from library

### DIFF
--- a/example/script.js
+++ b/example/script.js
@@ -2,6 +2,7 @@ import { soekSearch } from "../dist/soek.min.js";
 
 document.addEventListener("DOMContentLoaded", (event) => {
   const searchBar = document.getElementById("search-bar");
+  const indexURL = "./search_index.json";
 
   searchBar.addEventListener("input", async () => {
     const matchesDiv = document.getElementById("matches");
@@ -11,9 +12,11 @@ document.addEventListener("DOMContentLoaded", (event) => {
       return; // don't search if the search bar is empty
     }
 
+    const index = JSON.stringify(await (await fetch(indexURL)).json()); // fetch the index file and convert it to JSON string
+
     const config = {
       key: searchBar.value,
-      indexURL: "./search_index.json",
+      index: index,
     };
 
     const matches = await soekSearch(config);

--- a/scripts/soek.js
+++ b/scripts/soek.js
@@ -36,7 +36,7 @@ var wasmURL = new URL("./soek.wasm", scriptURL);
  * @param {string} indexURL - The URL of the index.json file.
  * @returns {Promise} A promise that resolves with the matches of the search results.
  */
-export const soekSearch = async ({ key, indexURL }) => {
+export const soekSearch = async ({ key, index }) => {
   const importObject = go.importObject;
   const wasmModule = await wasmBrowserInstantiate(wasmURL, importObject);
 
@@ -47,16 +47,10 @@ export const soekSearch = async ({ key, indexURL }) => {
     return;
   }
 
-  if (!indexURL) {
-    console.error("Index URL is undefined");
+  if (!index) {
+    console.error("No index provided");
     return;
   }
 
-  return fetch(indexURL)
-    .then((response) => response.json())
-    .then((indexJSON) => {
-      const index = JSON.stringify(indexJSON);
-
-      return callSearch(key, index);
-    });
+  return callSearch(key, index);
 };


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Moves fetching the index file from the library to outside the library as it makes much more sense. You only need to provide a JSON index string to the library and it will deal with it.