### PR TITLE
fix: move JSON unmarshal to main

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"syscall/js"
 
 	"github.com/pottekkat/soek/pkg/soek"
 )
+
+var index []map[string]interface{}
 
 func main() {
 	// Reference: https://www.aaron-powell.com/posts/2019-02-06-golang-wasm-3-interacting-with-js-from-go/
@@ -16,7 +19,13 @@ func main() {
 
 // callSearch exposes the functionality of soek.Search to JavaScript
 func callSearch(this js.Value, args []js.Value) interface{} {
-	matches := soek.Search(args[0].String(), args[1].String())
+	err := json.Unmarshal([]byte(args[1].String()), &index)
+	if err != nil {
+		println("could not unmarshal JSON: %s\n", err)
+		return nil
+	}
+	key := args[0].String()
+	matches := soek.Search(key, index)
 	jsArray := js.Global().Get("Array").New(len(matches))
 	for i, val := range matches {
 		jsArray.SetIndex(i, js.ValueOf(val))

--- a/pkg/soek/soek.go
+++ b/pkg/soek/soek.go
@@ -1,21 +1,13 @@
 package soek
 
 import (
-	"encoding/json"
 	"strings"
 )
 
-var index []map[string]interface{}
 var matches []map[string]interface{}
 
 // Search looks for the given key in the index and returns a list of matched titles
-func Search(key string, indexJSONString string) []map[string]interface{} {
-	err := json.Unmarshal([]byte(indexJSONString), &index)
-	if err != nil {
-		println("could not unmarshal JSON: %s\n", err)
-		return nil
-	}
-
+func Search(key string, index []map[string]interface{}) []map[string]interface{} {
 	for _, i := range index {
 		for k, v := range i {
 			if str, ok := v.(string); ok {


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Moves JSON unmarshal to main so that the function in the soek package remains clean and accepts a map rather than a string. This makes it easy to use it as a standalone package.